### PR TITLE
feat: in favor of function "templatefiles"

### DIFF
--- a/instances/main.tf
+++ b/instances/main.tf
@@ -93,17 +93,13 @@ resource "aws_security_group" "sg_22_80" {
   }
 }
 
-data "template_file" "user_data" {
-  template = file("../scripts/add-ssh-web-app.yaml")
-}
-
 resource "aws_instance" "web" {
   ami                         = data.aws_ami.ubuntu.id
   instance_type               = "t2.micro"
   subnet_id                   = aws_subnet.subnet_public.id
   vpc_security_group_ids      = [aws_security_group.sg_22_80.id]
   associate_public_ip_address = true
-  user_data                   = data.template_file.user_data.rendered
+  user_data                   = templatefile("${path.module}/scripts/add-ssh-web-app.yaml")
 
   tags = {
     Name = "Learn-CloudInit"


### PR DESCRIPTION
- to use "templatefiles" function instead of "data source "template_file" for any core version >= 0.12
- ref:  https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file